### PR TITLE
update ATXN1 locus structure

### DIFF
--- a/str_analysis/variant_catalogs/variant_catalog_with_offtargets.GRCh37.json
+++ b/str_analysis/variant_catalogs/variant_catalog_with_offtargets.GRCh37.json
@@ -247,7 +247,7 @@
    },
    {
       "LocusId": "ATXN1",
-      "LocusStructure": "(TGC)*",
+      "LocusStructure": "(CAG)*",
       "ReferenceRegion": "chr6:16327864-16327954",
       "VariantType": "RareRepeat",
       "Gene": "ATXN1",

--- a/str_analysis/variant_catalogs/variant_catalog_with_offtargets.GRCh38.json
+++ b/str_analysis/variant_catalogs/variant_catalog_with_offtargets.GRCh38.json
@@ -246,7 +246,7 @@
    },
    {
       "LocusId": "ATXN1",
-      "LocusStructure": "(TGC)*",
+      "LocusStructure": "(CAG)*",
       "ReferenceRegion": "chr6:16327633-16327723",
       "VariantType": "RareRepeat",
       "Gene": "ATXN1",

--- a/str_analysis/variant_catalogs/variant_catalog_without_offtargets.GRCh37.json
+++ b/str_analysis/variant_catalogs/variant_catalog_without_offtargets.GRCh37.json
@@ -133,7 +133,7 @@
    },
    {
       "LocusId": "ATXN1",
-      "LocusStructure": "(TGC)*",
+      "LocusStructure": "(CAG)*",
       "ReferenceRegion": "chr6:16327864-16327954",
       "VariantType": "Repeat",
       "Gene": "ATXN1",

--- a/str_analysis/variant_catalogs/variant_catalog_without_offtargets.GRCh38.json
+++ b/str_analysis/variant_catalogs/variant_catalog_without_offtargets.GRCh38.json
@@ -133,7 +133,7 @@
    },
    {
       "LocusId": "ATXN1",
-      "LocusStructure": "(TGC)*",
+      "LocusStructure": "(CAG)*",
       "ReferenceRegion": "chr6:16327633-16327723",
       "VariantType": "Repeat",
       "Gene": "ATXN1",


### PR DESCRIPTION
According to [STRipy](https://stripy.org/database/ATXN1) and [OMIM](https://www.omim.org/entry/601556), it looks like ATXN1 has a trinucleotide repeat of `CAG`, not `TGC`. I've updated the 4 variant catalogues accordingly. 

Let me know if I'm missing something, or if this looks ok. 