### PR TITLE
Include interrupting sequence in a compound repeat definition

### DIFF
--- a/str_analysis/convert_expansion_hunter_variant_catalog_to_trgt_catalog.py
+++ b/str_analysis/convert_expansion_hunter_variant_catalog_to_trgt_catalog.py
@@ -80,7 +80,7 @@ def process_expansion_hunter_catalog(expansion_hunter_catalog_path, output_file_
                         ])
                 else:
                     motif_string = ",".join(motifs)
-                    struc = "".join([f"({motif})n" for motif in motifs])
+                    struc = locus_structure.replace("*", "n")
 
                     output_rows.append([
                         chrom,


### PR DESCRIPTION
The current implementation drops the interrupting sequence (if any) between two motifs if an STR locus has multiple motifs specified. 
For example, HTT specs:  (CAG)\*CAACAG(CCG)\* will get converted to "(CAG)n(CCG)n". 

But in the TRGT docs they keep the interrupting sequence eg for HTT: https://github.com/PacificBiosciences/trgt/blob/main/docs/repeat_files.md
