### PR TITLE
Manually parse SampleId column as String

### DIFF
--- a/str_analysis/convert_multisample_LPS_table_to_allele_frequency_histograms.py
+++ b/str_analysis/convert_multisample_LPS_table_to_allele_frequency_histograms.py
@@ -216,7 +216,7 @@ def main():
         strata_labels = []
     else:
         import pandas as pd
-        df_metadata = pd.read_table(args.sample_metadata_tsv)
+        df_metadata = pd.read_table(args.sample_metadata_tsv, dtype={"SampleId": str})
         all_sample_ids = set(df_metadata.SampleId)
         unexpected_sample_ids = set(sample_ids_in_input_table) - all_sample_ids
         if unexpected_sample_ids:


### PR DESCRIPTION
If `SampleId` values are integers, the `convert_multisample_LPS_table_to_allele_frequency_histograms.py` script breaks with the error below, as Pandas infers the data type from the metadata file columns.
```
usage: convert_multisample_LPS_table_to_allele_frequency_histograms.py
[-h] [--sample-metadata-tsv SAMPLE_METADATA_TSV]
[--input-table INPUT_TABLE] [--no-header]
[--population {AFR,AMR,EAS,EUR,SAS}] [--sex {male,female}]
[--stratify-by-population] [--stratify-by-sex]
[--output-format {TSV,JSON}] [-n NUM_SAMPLES] [-l NUM_LOCI]
convert_multisample_LPS_table_to_allele_frequency_histograms.py: error: X sample id(s) not found in /mnt/disks/cromwell_root/path-to-metadata-tsv: <list-of-integer-sample-ids>
```